### PR TITLE
Update utils.c

### DIFF
--- a/drivers/acpi/x86/utils.c
+++ b/drivers/acpi/x86/utils.c
@@ -62,13 +62,17 @@ static const struct always_present_id always_present_ids[] = {
 	 */
 	ENTRY("INT0002", "1", ICPU(INTEL_FAM6_ATOM_AIRMONT), {}),
 	/*
-	 * On the Dell Venue 11 Pro 7130 the DSDT hides the touchscreen ACPI
+	 * On the Dell Venue 11 Pro 7130 and 7139, the DSDT hides the touchscreen ACPI
 	 * device until a certain time after _SB.PCI0.GFX0.LCD.LCD1._ON gets
 	 * called has passed *and* _STA has been called at least 3 times since.
 	 */
 	ENTRY("SYNA7500", "1", ICPU(INTEL_FAM6_HASWELL_ULT), {
 		DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
 		DMI_MATCH(DMI_PRODUCT_NAME, "Venue 11 Pro 7130"),
+	      }),
+	ENTRY("SYNA7500", "1", ICPU(INTEL_FAM6_HASWELL_ULT), {
+		DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc."),
+		DMI_MATCH(DMI_PRODUCT_NAME, "Venue 11 Pro 7139"),
 	      }),
 	/*
 	 * The GPD win BIOS dated 20170221 has disabled the accelerometer, the


### PR DESCRIPTION
Added support for dmi matching the Dell Venue SYNA7500 Touchscreen, in addition to the 7130 which was already present. This utils.c was forked directly from bliss and edited for only this change. Hopefully, all original and proper credits stay intact. I am no git pro. If you have any questions, I am Rebel1699 in the Telegram group. Thanks, guys. 

Sources
https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1745342
https://lists.gt.net/linux/kernel/3009839